### PR TITLE
Add an ESM export to package.json

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 fast-deep-equal.js
 test/zora/fixtures
 coverage
+dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 package-lock.json
 .nyc_output
 .vscode
+dist/*.js

--- a/build.js
+++ b/build.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// @ts-check
+const path = require('path')
+const esbuild = require('esbuild')
+
+const debug = process.argv.includes('--debug')
+
+async function main () {
+  await build('index.js')
+}
+
+main()
+  .then(() => console.log('done building'))
+  .catch(err => console.log('err', err))
+
+/**
+ * @param {string} srcFile Path to source file
+ * @returns {Promise<[
+ *   import('esbuild').BuildResult,
+ *   import('esbuild').BuildResult
+ * ]>} Promise for building esm and cjs files
+ */
+function build (srcFile) {
+  const root = __dirname
+
+  return Promise.all([
+    esbuild.build({
+      entryPoints: [path.join(root, 'index.js')],
+      bundle: true,
+      keepNames: true,
+      minify: false,
+      format: 'esm',
+      define: { global: 'window' },
+      sourcemap: debug ? 'inline' : undefined,
+      outfile: path.join(root, 'dist',
+        path.basename(srcFile).replace('.js', '.esm.js')),
+      platform: 'browser'
+    }),
+
+    esbuild.build({
+      entryPoints: [path.join(root, 'index.js')],
+      bundle: true,
+      keepNames: true,
+      minify: false,
+      format: 'cjs',
+      define: { global: 'window' },
+      sourcemap: debug ? 'inline' : undefined,
+      outfile: path.join(root, 'dist/', path.basename(srcFile)),
+      platform: 'browser'
+    })
+  ])
+}

--- a/harness.js
+++ b/harness.js
@@ -123,7 +123,7 @@ class TapeHarness {
    * @returns {void}
    */
   _test (tapzeroFn, testName, options, fn) {
-    if (typeof options === 'function') {
+    if (!fn && typeof options === 'function') {
       fn = /** @type {(h: T, test: Test) => void} */ (options)
       options = {}
     }

--- a/harness.js
+++ b/harness.js
@@ -123,7 +123,7 @@ class TapeHarness {
    * @returns {void}
    */
   _test (tapzeroFn, testName, options, fn) {
-    if (!fn && typeof options === 'function') {
+    if (typeof options === 'function') {
       fn = /** @type {(h: T, test: Test) => void} */ (options)
       options = {}
     }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,12 +2,14 @@
   "extends": "./_types/base-tsconfig.json",
   "compilerOptions": {
     "baseUrl": "./",
+    "module": "commonjs",
     "paths": {
       "@pre-bundled/tape": ["./_types/pre-bundled__tape"],
       "@pre-bundled/rimraf": ["./_types/pre-bundled__rimraf"],
       "*" : ["./_types/*"]
     }
   },
+  "exclude": ["node_modules"],
   "include": [
     "_types/**/*.d.ts",
     "*.js",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,18 @@
   "name": "tapzero",
   "version": "0.6.1",
   "description": "Smallest test library",
-  "main": "index.js",
+  "main": "./dist/index.esm.js",
   "scripts": {
     "tsc": "npr tsc -p jsconfig.json --maxNodeModuleJsDepth 0",
     "lint": "npr tsdocstandard -v",
     "test": "npm run tsc && npm run lint && node test/harness.js && node test/index.js && npr type-coverage",
     "vendor": "cp node_modules/fast-deep-equal/index.js ./fast-deep-equal.js; sed -i '1s;^;// Copied from fast-deep-equal@3.1.1.\\n// @ts-nocheck\\n;' fast-deep-equal.js"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js"
+    }
   },
   "typeCoverage": {
     "atLeast": 98,
@@ -29,6 +35,7 @@
     "@pre-bundled/tape": "4.11.0",
     "@types/node": "13.7.4",
     "diff": "4.0.2",
+    "esbuild": "^0.15.11",
     "fast-deep-equal": "3.1.1",
     "npm-bin-deps": "1.10.1",
     "request": "2.88.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "tsc": "npr tsc -p jsconfig.json --maxNodeModuleJsDepth 0",
     "lint": "npr tsdocstandard -v",
     "test": "npm run tsc && npm run lint && node test/harness.js && node test/index.js && npr type-coverage",
+    "postversion": "git push && git push --tags",
     "vendor": "cp node_modules/fast-deep-equal/index.js ./fast-deep-equal.js; sed -i '1s;^;// Copied from fast-deep-equal@3.1.1.\\n// @ts-nocheck\\n;' fast-deep-equal.js"
   },
   "exports": {

--- a/test/unit/smoke.js
+++ b/test/unit/smoke.js
@@ -138,8 +138,8 @@ test('zerotap handles errors', (assert) => {
                   at Test.run ($TAPE/index.js:$LINE:$COL)
                   at TestRunner.run ($TAPE/index.js:$LINE:$COL)
                   at Timeout._onTimeout ($TAPE/index.js:$LINE:$COL)
-                  at listOnTimeout (node:internal/timers.js:$LINE:$COL)
-                  at processTimers (node:internal/timers.js:$LINE:$COL)
+                  at listOnTimeout (node:internal/timers:$LINE:$COL)
+                  at processTimers (node:internal/timers:$LINE:$COL)
           ...
 
         1..1
@@ -184,8 +184,8 @@ test('zerotap handles multiple asserts', (assert) => {
                   at Test.run ($TAPE/index.js:$LINE:$COL)
                   at TestRunner.run ($TAPE/index.js:$LINE:$COL)
                   at Timeout._onTimeout ($TAPE/index.js:$LINE:$COL)
-                  at listOnTimeout (node:internal/timers.js:$LINE:$COL)
-                  at processTimers (node:internal/timers.js:$LINE:$COL)
+                  at listOnTimeout (node:internal/timers:$LINE:$COL)
+                  at processTimers (node:internal/timers:$LINE:$COL)
           ...
 
         1..3
@@ -301,8 +301,8 @@ test('zerotap undefined is string', (assert) => {
                   at Test.run ($TAPE/index.js:$LINE:$COL)
                   at TestRunner.run ($TAPE/index.js:$LINE:$COL)
                   at Timeout._onTimeout ($TAPE/index.js:$LINE:$COL)
-                  at listOnTimeout (node:internal/timers.js:$LINE:$COL)
-                  at processTimers (node:internal/timers.js:$LINE:$COL)
+                  at listOnTimeout (node:internal/timers:$LINE:$COL)
+                  at processTimers (node:internal/timers:$LINE:$COL)
           ...
 
         1..1
@@ -343,8 +343,8 @@ test('zerotap fail', (assert) => {
                   at Test.run ($TAPE/index.js:$LINE:$COL)
                   at TestRunner.run ($TAPE/index.js:$LINE:$COL)
                   at Timeout._onTimeout ($TAPE/index.js:$LINE:$COL)
-                  at listOnTimeout (node:internal/timers.js:$LINE:$COL)
-                  at processTimers (node:internal/timers.js:$LINE:$COL)
+                  at listOnTimeout (node:internal/timers:$LINE:$COL)
+                  at processTimers (node:internal/timers:$LINE:$COL)
           ...
 
         1..1

--- a/test/unit/smoke.js
+++ b/test/unit/smoke.js
@@ -138,8 +138,8 @@ test('zerotap handles errors', (assert) => {
                   at Test.run ($TAPE/index.js:$LINE:$COL)
                   at TestRunner.run ($TAPE/index.js:$LINE:$COL)
                   at Timeout._onTimeout ($TAPE/index.js:$LINE:$COL)
-                  at listOnTimeout (internal/timers.js:$LINE:$COL)
-                  at processTimers (internal/timers.js:$LINE:$COL)
+                  at listOnTimeout (node:internal/timers.js:$LINE:$COL)
+                  at processTimers (node:internal/timers.js:$LINE:$COL)
           ...
 
         1..1
@@ -184,8 +184,8 @@ test('zerotap handles multiple asserts', (assert) => {
                   at Test.run ($TAPE/index.js:$LINE:$COL)
                   at TestRunner.run ($TAPE/index.js:$LINE:$COL)
                   at Timeout._onTimeout ($TAPE/index.js:$LINE:$COL)
-                  at listOnTimeout (internal/timers.js:$LINE:$COL)
-                  at processTimers (internal/timers.js:$LINE:$COL)
+                  at listOnTimeout (node:internal/timers.js:$LINE:$COL)
+                  at processTimers (node:internal/timers.js:$LINE:$COL)
           ...
 
         1..3
@@ -301,8 +301,8 @@ test('zerotap undefined is string', (assert) => {
                   at Test.run ($TAPE/index.js:$LINE:$COL)
                   at TestRunner.run ($TAPE/index.js:$LINE:$COL)
                   at Timeout._onTimeout ($TAPE/index.js:$LINE:$COL)
-                  at listOnTimeout (internal/timers.js:$LINE:$COL)
-                  at processTimers (internal/timers.js:$LINE:$COL)
+                  at listOnTimeout (node:internal/timers.js:$LINE:$COL)
+                  at processTimers (node:internal/timers.js:$LINE:$COL)
           ...
 
         1..1
@@ -343,8 +343,8 @@ test('zerotap fail', (assert) => {
                   at Test.run ($TAPE/index.js:$LINE:$COL)
                   at TestRunner.run ($TAPE/index.js:$LINE:$COL)
                   at Timeout._onTimeout ($TAPE/index.js:$LINE:$COL)
-                  at listOnTimeout (internal/timers.js:$LINE:$COL)
-                  at processTimers (internal/timers.js:$LINE:$COL)
+                  at listOnTimeout (node:internal/timers.js:$LINE:$COL)
+                  at processTimers (node:internal/timers.js:$LINE:$COL)
           ...
 
         1..1

--- a/test/zora/fixtures/adding_test_cases_async_fail_out.txt
+++ b/test/zora/fixtures/adding_test_cases_async_fail_out.txt
@@ -15,5 +15,5 @@ Error: Cannot add() a test case after tests completed.
     at TestRunner.add ($TAPE/index.js:$LINE:$COL)
     at test ($TAPE/index.js:$LINE:$COL)
     at Timeout._onTimeout ($TEST/zora/fixtures/adding_test_cases_async_fail.js:$LINE:$COL)
-    at listOnTimeout (internal/timers.js:$LINE:$COL)
-    at processTimers (internal/timers.js:$LINE:$COL)
+    at listOnTimeout (node:internal/timers.js:$LINE:$COL)
+    at processTimers (node:internal/timers.js:$LINE:$COL)

--- a/test/zora/fixtures/adding_test_cases_async_fail_out.txt
+++ b/test/zora/fixtures/adding_test_cases_async_fail_out.txt
@@ -15,5 +15,5 @@ Error: Cannot add() a test case after tests completed.
     at TestRunner.add ($TAPE/index.js:$LINE:$COL)
     at test ($TAPE/index.js:$LINE:$COL)
     at Timeout._onTimeout ($TEST/zora/fixtures/adding_test_cases_async_fail.js:$LINE:$COL)
-    at listOnTimeout (node:internal/timers.js:$LINE:$COL)
-    at processTimers (node:internal/timers.js:$LINE:$COL)
+    at listOnTimeout (node:internal/timers:$LINE:$COL)
+    at processTimers (node:internal/timers:$LINE:$COL)

--- a/test/zora/fixtures/bailout_fail_out.txt
+++ b/test/zora/fixtures/bailout_fail_out.txt
@@ -10,5 +10,5 @@ Error: Oh no!
     at Test.run ($TAPE/index.js:$LINE:$COL)
     at TestRunner.run ($TAPE/index.js:$LINE:$COL)
     at Timeout._onTimeout ($TAPE/index.js:$LINE:$COL)
-    at listOnTimeout (internal/timers.js:$LINE:$COL)
-    at processTimers (internal/timers.js:$LINE:$COL)
+    at listOnTimeout (node:internal/timers:$LINE:$COL)
+    at processTimers (node:internal/timers:$LINE:$COL)


### PR DESCRIPTION
Add to package.json
```js
  "exports": {
    ".": {
      "import": "./dist/index.esm.js",
      "require": "./dist/index.js"
    }
  },
```

And a build script that converts the source code (common js) into ESM.

* tests pass
* Should still be usable in common JS
