### PR TITLE
fix: display undefined in error reports

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,8 +233,8 @@ class Test {
     report('  ---')
     report(`    operator: ${operator}`)
 
-    let ex = JSON.stringify(expected, null, '  ') || 'undefined'
-    let ac = JSON.stringify(actual, null, '  ') || 'undefined'
+    let ex = toJSON(expected)
+    let ac = toJSON(actual)
     if (Math.max(ex.length, ac.length) > 65) {
       ex = ex.replace(NEW_LINE_REGEX, '\n      ')
       ac = ac.replace(NEW_LINE_REGEX, '\n      ')
@@ -532,4 +532,19 @@ function rethrowImmediate (err) {
    * @returns {void}
    */
   function rethrow () { throw err }
+}
+
+/**
+ * JSON.stringify `thing` while preserving `undefined` values in
+ * the output.
+ *
+ * @param {unknown} thing
+ * @returns {string}
+ */
+function toJSON (thing) {
+  /** @type {(_k: string, v: unknown) => unknown} */
+  const replacer = (_k, v) => (v === undefined) ? '_tz_undefined_tz_' : v
+
+  const json = JSON.stringify(thing, replacer, '  ') || 'undefined'
+  return json.replace(/"_tz_undefined_tz_"/g, 'undefined')
 }


### PR DESCRIPTION
Fixes #12.

No additional dependencies, no additional requires. Just show `undefined` in report output when there is an undefined value in the json.