### PR TITLE
Add a method `plan`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ The implementation is <250 loc, (<500 with comments) ( https://github.com/Raynos
 ## Migrating from tape
 
 ```js
-const test = require('tape')
+const tape = require('tape')
 // Tapzero exports an object with a test function property.
-const test = require('tapzero').test
+const tapzero = require('tapzero').test
 ```
 
 ```js
@@ -26,6 +26,7 @@ tapzero('my test', (t) => {
 })
 ```
 
+### End "automatically" if you do not call `t.plan`
 ```js
 // tapzero "auto" ends async tests when the async function completes
 tapzero('my cb test', async (t) => {
@@ -36,6 +37,17 @@ tapzero('my cb test', async (t) => {
       resolve()
     }, 10)
   })
+})
+```
+
+### Plan the number of assertions
+```js
+tapzero('planning example', t => {
+  // this test will fail if we execute more or fewer
+  //   than planned assertions
+  t.plan(2)
+  t.ok('hello')
+  t.equal(2, 2, 'two is two')
 })
 ```
 

--- a/index.js
+++ b/index.js
@@ -35,6 +35,10 @@ class Test {
   constructor (name, fn, runner) {
     /** @type {string} */
     this.name = name
+    /** @type {null|number} */
+    this._planned = null
+    /** @type {null|number} */
+    this._actual = null
     /** @type {TestFn} */
     this.fn = fn
     /** @type {TestRunner} */
@@ -57,6 +61,16 @@ class Test {
    */
   comment (msg) {
     this.runner.report('# ' + msg)
+  }
+
+  /**
+   * Plan the number of assertions.
+   *
+   * @param {number} n
+   * @returns {void}
+   */
+  plan (n) {
+    this._planned = n
   }
 
   /**
@@ -211,6 +225,14 @@ class Test {
       )
     }
 
+    if (this._planned !== null) {
+      this._actual = ((this._actual || 0) + 1)
+
+      if (this._actual > this._planned) {
+        throw new Error(`More tests than planned in TEST *${this.name}*`)
+      }
+    }
+
     const report = this.runner.report
 
     const prefix = pass ? 'ok' : 'not ok'
@@ -272,7 +294,19 @@ class Test {
     if (maybeP && typeof maybeP.then === 'function') {
       await maybeP
     }
+
     this.done = true
+
+    if (this._planned !== null && this._actual !== null) {
+      if (this._planned > this._actual) {
+        throw new Error(`Test ended before the planned number
+          planned: ${this._planned}
+          actual: ${this._actual}
+          `
+        )
+      }
+    }
+
     return this._result
   }
 }

--- a/test/unit/smoke.js
+++ b/test/unit/smoke.js
@@ -7,7 +7,7 @@ const test = require('@pre-bundled/tape')
 const { TestRunner } = require('../../index.js')
 const { collect, trimPrefix } = require('../util.js')
 
-test('zerotap outputs TAP', (assert) => {
+test('tapzero outputs TAP', (assert) => {
   const h = new TestRunner(collect(verify))
   h.add('one', (t) => {
     t.ok(true)
@@ -33,7 +33,7 @@ test('zerotap outputs TAP', (assert) => {
   }
 })
 
-test('zerotap with two blocks', (assert) => {
+test('tapzero with two blocks', (assert) => {
   const h = new TestRunner(collect(verify))
   h.add('one', (t) => {
     t.ok(true)
@@ -139,7 +139,7 @@ test('zerotap handles errors', (assert) => {
                   at TestRunner.run ($TAPE/index.js:$LINE:$COL)
                   at Timeout._onTimeout ($TAPE/index.js:$LINE:$COL)
                   at listOnTimeout (node:internal/timers:$LINE:$COL)
-                  at processTimers (node:internal/timers:$LINE:$COL)
+                  at process.processTimers (node:internal/timers:$LINE:$COL)
           ...
 
         1..1
@@ -185,7 +185,7 @@ test('zerotap handles multiple asserts', (assert) => {
                   at TestRunner.run ($TAPE/index.js:$LINE:$COL)
                   at Timeout._onTimeout ($TAPE/index.js:$LINE:$COL)
                   at listOnTimeout (node:internal/timers:$LINE:$COL)
-                  at processTimers (node:internal/timers:$LINE:$COL)
+                  at process.processTimers (node:internal/timers:$LINE:$COL)
           ...
 
         1..3
@@ -302,7 +302,7 @@ test('zerotap undefined is string', (assert) => {
                   at TestRunner.run ($TAPE/index.js:$LINE:$COL)
                   at Timeout._onTimeout ($TAPE/index.js:$LINE:$COL)
                   at listOnTimeout (node:internal/timers:$LINE:$COL)
-                  at processTimers (node:internal/timers:$LINE:$COL)
+                  at process.processTimers (node:internal/timers:$LINE:$COL)
           ...
 
         1..1
@@ -344,7 +344,7 @@ test('zerotap fail', (assert) => {
                   at TestRunner.run ($TAPE/index.js:$LINE:$COL)
                   at Timeout._onTimeout ($TAPE/index.js:$LINE:$COL)
                   at listOnTimeout (node:internal/timers:$LINE:$COL)
-                  at processTimers (node:internal/timers:$LINE:$COL)
+                  at process.processTimers (node:internal/timers:$LINE:$COL)
           ...
 
         1..1

--- a/test/util.js
+++ b/test/util.js
@@ -62,7 +62,14 @@ function strip (line) {
     /, <anonymous>:\$LINE:\$COL\)$/, ')'
   )
 
-  const lines = withoutNestedLineNumbers.split('\n')
+  const withoutNodeVersion = withoutNestedLineNumbers.replace(
+    // new RegExp('Node.js*'),
+    /^Node.js.*$/gm,
+    ''
+  )
+
+  // const lines = withoutNestedLineNumbers.split('\n')
+  const lines = withoutNodeVersion.split('\n')
   const newLines = lines.filter((line) => {
     return !line.includes('internal/process/task_queues.js') &&
             !line.includes('internal/process/next_tick.js') &&

--- a/test/zora/fixtures/adding_test_cases_async_fail_out.txt
+++ b/test/zora/fixtures/adding_test_cases_async_fail_out.txt
@@ -16,4 +16,4 @@ Error: Cannot add() a test case after tests completed.
     at test ($TAPE/index.js:$LINE:$COL)
     at Timeout._onTimeout ($TEST/zora/fixtures/adding_test_cases_async_fail.js:$LINE:$COL)
     at listOnTimeout (node:internal/timers:$LINE:$COL)
-    at processTimers (node:internal/timers:$LINE:$COL)
+    at process.processTimers (node:internal/timers:$LINE:$COL)

--- a/test/zora/fixtures/bailout_fail.js
+++ b/test/zora/fixtures/bailout_fail.js
@@ -5,9 +5,9 @@ test('will not go to the end', function _(t) {
 
     throw new Error('Oh no!');
 
-    t.ok(true, 'will never be reached');
+    t.fail('should never be reached')
 });
 
 test('another one', t => {
-    t.ok(true, 'will never be reported');
+    t.fail('should never be reported');
 });

--- a/test/zora/fixtures/bailout_fail_out.txt
+++ b/test/zora/fixtures/bailout_fail_out.txt
@@ -11,4 +11,4 @@ Error: Oh no!
     at TestRunner.run ($TAPE/index.js:$LINE:$COL)
     at Timeout._onTimeout ($TAPE/index.js:$LINE:$COL)
     at listOnTimeout (node:internal/timers:$LINE:$COL)
-    at processTimers (node:internal/timers:$LINE:$COL)
+    at process.processTimers (node:internal/timers:$LINE:$COL)

--- a/test/zora/fixtures/plan.js
+++ b/test/zora/fixtures/plan.js
@@ -1,0 +1,7 @@
+const test = require('../../../index').test
+
+test('Plan the correct number of tests', t => {
+    t.plan(2)
+    t.ok('example')
+    t.ok('example')
+})

--- a/test/zora/fixtures/plan.js
+++ b/test/zora/fixtures/plan.js
@@ -5,3 +5,21 @@ test('Plan the correct number of tests', t => {
     t.ok('example')
     t.ok('example')
 })
+
+test('.plan with an async function', async t => {
+    t.plan(2)
+    await sleep(10)
+    t.ok('hello')
+    await sleep(20)
+    t.ok('hello')
+})
+
+/**
+ * Wait for a number of miliseconds.
+ * @param {number} ms 
+ */
+async function sleep (ms) {
+    await new Promise((resolve) => {
+        setTimeout(resolve, ms)
+    })
+}

--- a/test/zora/fixtures/plan_fail.js
+++ b/test/zora/fixtures/plan_fail.js
@@ -1,0 +1,8 @@
+const test = require('../../../index').test
+
+test('Plan an incorrect number of tests', t => {
+    t.plan(1)
+    t.ok('example')
+    t.ok('example')
+})
+

--- a/test/zora/fixtures/plan_fail.js
+++ b/test/zora/fixtures/plan_fail.js
@@ -5,4 +5,3 @@ test('Plan an incorrect number of tests', t => {
     t.ok('example')
     t.ok('example')
 })
-

--- a/test/zora/fixtures/plan_fail_out.txt
+++ b/test/zora/fixtures/plan_fail_out.txt
@@ -1,0 +1,16 @@
+TAP version 13
+# Plan an incorrect number of tests
+ok 1 should be truthy
+$TAPE/index.js:$LINE
+  function rethrow () { throw err }
+                        ^
+
+Error: More tests than planned in TEST *Plan an incorrect number of tests*
+    at Test._assert ($TAPE/index.js:$LINE:$COL)
+    at Test.ok ($TAPE/index.js:$LINE:$COL)
+    at Test.fn ($TEST/zora/fixtures/plan_fail.js:$LINE:$COL)
+    at Test.run ($TAPE/index.js:$LINE:$COL)
+    at TestRunner.run ($TAPE/index.js:$LINE:$COL)
+    at Timeout._onTimeout ($TAPE/index.js:$LINE:$COL)
+    at listOnTimeout (node:internal/timers:$LINE:$COL)
+    at process.processTimers (node:internal/timers:$LINE:$COL)

--- a/test/zora/fixtures/plan_not_enough_fail.js
+++ b/test/zora/fixtures/plan_not_enough_fail.js
@@ -1,0 +1,7 @@
+const test = require('../../../index').test
+
+test('Execute fewer tests than planned', t => {
+    t.plan(3)
+    t.ok('example')
+    t.ok('example 2')
+})

--- a/test/zora/fixtures/plan_not_enough_fail_out.txt
+++ b/test/zora/fixtures/plan_not_enough_fail_out.txt
@@ -1,0 +1,17 @@
+TAP version 13
+# Execute fewer tests than planned
+ok 1 should be truthy
+ok 2 should be truthy
+$TAPE/index.js:$LINE
+  function rethrow () { throw err }
+                        ^
+
+Error: Test ended before the planned number
+          planned: 3
+          actual: 2
+          
+    at Test.run ($TAPE/index.js:$LINE:$COL)
+    at TestRunner.run ($TAPE/index.js:$LINE:$COL)
+    at Timeout._onTimeout ($TAPE/index.js:$LINE:$COL)
+    at listOnTimeout (node:internal/timers:$LINE:$COL)
+    at process.processTimers (node:internal/timers:$LINE:$COL)

--- a/test/zora/fixtures/plan_out.txt
+++ b/test/zora/fixtures/plan_out.txt
@@ -2,9 +2,12 @@ TAP version 13
 # Plan the correct number of tests
 ok 1 should be truthy
 ok 2 should be truthy
+# .plan with an async function
+ok 3 should be truthy
+ok 4 should be truthy
 
-1..2
-# tests 2
-# pass  2
+1..4
+# tests 4
+# pass  4
 
 # ok

--- a/test/zora/fixtures/plan_out.txt
+++ b/test/zora/fixtures/plan_out.txt
@@ -1,0 +1,10 @@
+TAP version 13
+# Plan the correct number of tests
+ok 1 should be truthy
+ok 2 should be truthy
+
+1..2
+# tests 2
+# pass  2
+
+# ok

--- a/test/zora/test-cases.js
+++ b/test/zora/test-cases.js
@@ -32,7 +32,6 @@ for (const file of JS_FILES) {
         fileName.replace('.js', '_out.txt'),
         'utf8'
       )
-      // t.ok(stripped.includes(expected), 'output is a superset of expected text')
       equalDiff(t, stripped.trim(), expected.trim())
     })().then(t.end, t.end)
   })

--- a/test/zora/test-cases.js
+++ b/test/zora/test-cases.js
@@ -29,9 +29,11 @@ for (const file of JS_FILES) {
       const stripped = strip(info.combined)
 
       const expected = await readFile(
-        fileName.replace('.js', '_out.txt'), 'utf8'
+        fileName.replace('.js', '_out.txt'),
+        'utf8'
       )
-      equalDiff(t, stripped, expected)
+      // t.ok(stripped.includes(expected), 'output is a superset of expected text')
+      equalDiff(t, stripped.trim(), expected.trim())
     })().then(t.end, t.end)
   })
 }


### PR DESCRIPTION
Fix #14 

Add a method `t.plan` so you can set a pre-determined number of tests to run. If you do not use `t.plan`, then the test closes "automatically", as it does currently.