### PR TITLE
Fix .plan method

### DIFF
--- a/index.js
+++ b/index.js
@@ -297,8 +297,8 @@ class Test {
 
     this.done = true
 
-    if (this._planned !== null && this._actual !== null) {
-      if (this._planned > this._actual) {
+    if (this._planned !== null) {
+      if (this._planned > (this._actual || 0)) {
         throw new Error(`Test ended before the planned number
           planned: ${this._planned}
           actual: ${this._actual}


### PR DESCRIPTION
It's better this way because we check if `_planned` exists, which is what we care about. Fixes the scenario where you plan for tests but never make any assertions.